### PR TITLE
Refactor Fantasy Pros Scraper Implementation

### DIFF
--- a/scrape_and_score/__main__.py
+++ b/scrape_and_score/__main__.py
@@ -16,8 +16,11 @@ def main():
    #Load Configurations from YAML file
    config = load_configs() 
    
+   template_url = config['website']['fantasy-pros']['urls']['depth-chart']
+   teams = [team['name'] for team in config['nfl']['teams']] # extract teams from configs
+   
    #Fetch relevant NFL teams & players
-   teams_and_players = scrape_fantasy_pros(config['website']['fantasy-pros']['urls']['depth-chart'])
+   teams_and_players = scrape_fantasy_pros(template_url, teams)
    logging.info(f"Successfully fetched {len(teams_and_players)} unique fantasy relevant players and their corresponding teams")
    
    #Fetch relevant team and player metrics 

--- a/scrape_and_score/resources/application.yaml
+++ b/scrape_and_score/resources/application.yaml
@@ -6,7 +6,7 @@ website:
          player-metrics: "https://www.pro-football-reference.com/players/{LAST_NAME_INITAL}/{HASHED_NAME}.htm"
    fantasy-pros:
       urls:
-         depth-chart: "https://www.fantasypros.com/nfl/depth-charts.php"
+         depth-chart: "https://www.fantasypros.com/nfl/depth-chart/{TEAM}.php"
 
 nfl:
    current-year: 2024

--- a/scrape_and_score/scraping/fantasy_pros_scraper.py
+++ b/scrape_and_score/scraping/fantasy_pros_scraper.py
@@ -76,7 +76,11 @@ def get_depth_chart(soup: BeautifulSoup, team: str):
          if len(cells) >= 2:  # ensure cell exists for name & position
                position = cells[0].get_text(strip=True) 
                name = cells[1].get_text(strip=True)
-            
+
+               # ensure cells contains valid data
+               if position == "" or name == "":
+                  continue
+               
                # add player 
                players_data.append({"player_name": name, "position": position[:2], "team": team})
    

--- a/scrape_and_score/scraping/pfr_scraper.py
+++ b/scrape_and_score/scraping/pfr_scraper.py
@@ -185,7 +185,7 @@ def collect_team_data(team: str, raw_html: str, year: int):
         points_allowed = extract_int(games[i], 'pts_def')
 
         
-        tot_yds, pass_yds, rush_yds, opp_tot_yds, opp_pass_yds, opp_rush_yds = calculate_yardage_totals(games)
+        tot_yds, pass_yds, rush_yds, opp_tot_yds, opp_pass_yds, opp_rush_yds = calculate_yardage_totals(games, i)
 
         # add row to data frame
         df.loc[len(df.index)] = [

--- a/scrape_and_score/tests/scraping/fantasy_pros_scraper_test.py
+++ b/scrape_and_score/tests/scraping/fantasy_pros_scraper_test.py
@@ -3,76 +3,113 @@ from bs4 import BeautifulSoup
 from scraping import fantasy_pros_scraper 
 
 
-soup = None
+@patch('scraping.fantasy_pros_scraper.construct_url', return_value = 'URL')
+@patch('scraping.fantasy_pros_scraper.fetch_page', return_value = None)
+@patch('scraping.fantasy_pros_scraper.get_depth_chart')
+@patch('scraping.fantasy_pros_scraper.BeautifulSoup')
+def test_scrape_returns_expected_data(mock_soup, mock_get_depth_chart, mock_fetch_page, mock_construct_url): 
+    base_url = 'https://www.fantasypros.com/nfl/depth-chart/{TEAM}.php'
+    teams = ['Indianapolis Colts']
+    expected_data = [{'player_name': 'Anthony Richardson', 'position': 'QB', 'team': 'Indianapolis Colts'}]
+    mock_get_depth_chart.return_value = expected_data
+    mock_soup.return_value = None
+    
+    data = fantasy_pros_scraper.scrape(base_url, teams)
+    
+    assert data == expected_data
 
-def setUpModule():
-    """Module-level setup for initializing soup with sample HTML."""
-    global soup
-    html_content = """
-    <div class="team-list">
-        <input class="team-name" value="New England Patriots" />
-        <div class="position-list">
-            <h4 class="position-head">ECR Quarterbacks</h4>
-            <a class="fp-player-link" fp-player-name="Mac Jones"></a>
-        </div>
-        <div class="position-list">
-            <h4 class="position-head">ECR Running Backs</h4>
-            <a class="fp-player-link" fp-player-name="Rhamondre Stevenson"></a>
-            <a class="fp-player-link" fp-player-name="Ezekiel Elliott"></a>
-        </div>
-    </div>
-    <div class="team-list">
-        <input class="team-name" value="Kansas City Chiefs" />
-        <div class="position-list">
-            <h4 class="position-head">ECR Quarterbacks</h4>
-            <a class="fp-player-link" fp-player-name="Patrick Mahomes"></a>
-        </div>
-        <div class="position-list">
-            <h4 class="position-head">ECR Tight Ends</h4>
-            <a class="fp-player-link" fp-player-name="Travis Kelce"></a>
-        </div>
-    </div>
+@patch('scraping.fantasy_pros_scraper.construct_url', return_value = 'URL')
+@patch('scraping.fantasy_pros_scraper.fetch_page', return_value = None)
+@patch('scraping.fantasy_pros_scraper.get_depth_chart')
+@patch('scraping.fantasy_pros_scraper.BeautifulSoup')
+def test_scrape_calls_expected_functions(mock_soup, mock_get_depth_chart, mock_fetch_page, mock_construct_url): 
+    base_url = 'https://www.fantasypros.com/nfl/depth-chart/{TEAM}.php'
+    teams = ['Indianapolis Colts']
+    expected_data = [{'player_name': 'Anthony Richardson', 'position': 'QB', 'team': 'Indianapolis Colts'}]
+    mock_get_depth_chart.return_value = expected_data
+    mock_soup.return_value = None
+    
+    fantasy_pros_scraper.scrape(base_url, teams)
+    
+    mock_soup.assert_called_once()
+    mock_get_depth_chart.assert_called_once() 
+    mock_construct_url.assert_called_once() 
+    mock_fetch_page.assert_called_once()
+    
+    
+    
+def test_construct_url_constructs_correct_url(): 
+    base_url = 'https://www.fantasypros.com/nfl/depth-chart/{TEAM}.php'
+    expected_url = 'https://www.fantasypros.com/nfl/depth-chart/arizona-cardinals.php'
+    team = 'Arizona Cardinals'
+    
+    actual_url = fantasy_pros_scraper.construct_url(team, base_url)
+    
+    assert actual_url == expected_url
+
+    
+def test_get_depth_chart_returns_expected_depth_chart():
+    html = """
+    <html>
+        <body>
+            <table>
+                <tr>
+                    <td>QB</td>
+                    <td>Anthony Richardson</td>
+                </tr>
+                <tr>
+                    <td>RB</td>
+                    <td>Jonathan Taylor</td>
+                </tr>
+            </table>
+        </body>
+    </html>
     """
-    # Parse HTML content with BeautifulSoup and assign to the global variable
-    soup = BeautifulSoup(html_content, "html.parser")
-
-
-@patch('scraping.util.fetch_page')
-@patch('scraping.fantasy_pros_scraper.fetch_team_data')
-def test_scrape(mock_fetch_team_data, mock_fetch_page):
-   # arrange 
-   url = "https://fantasypros.com"
-   mock_html = "<html><body></body></html>"
-   mock_fetch_page.return_value = mock_html
-   expected_values = [
-         {'team': 'Team A', 'position': 'QB', 'player_name': 'Player 1'},
-         {'team': 'Team A', 'position': 'QB', 'player_name': 'Player 2'}
-   ]
-   mock_fetch_team_data.return_value = expected_values
-   
-   # act 
-   result = fantasy_pros_scraper.scrape(url)
-   
-   # assert 
-   assert result == expected_values
-   
-   
-   
-
-def test_fetch_team_data():
+    soup = BeautifulSoup(html, 'html.parser')
+    team = "Indianapolis Colts"
     
-    # arrange 
-    expected_output = [
-        {'team': 'New England Patriots', 'position': 'QB', 'player_name': 'Mac Jones'},
-        {'team': 'New England Patriots', 'position': 'RB', 'player_name': 'Rhamondre Stevenson'},
-        {'team': 'New England Patriots', 'position': 'RB', 'player_name': 'Ezekiel Elliott'},
-        {'team': 'Kansas City Chiefs', 'position': 'QB', 'player_name': 'Patrick Mahomes'},
-        {'team': 'Kansas City Chiefs', 'position': 'TE', 'player_name': 'Travis Kelce'},
+    expected_data = [
+        {"player_name": "Anthony Richardson", "position": "QB", "team": team},
+        {"player_name": "Jonathan Taylor", "position": "RB", "team": team}
     ]
+    
+    result = fantasy_pros_scraper.get_depth_chart(soup, team)
+    assert result == expected_data
+    
+    
 
-    # act 
-    actual_output = fantasy_pros_scraper.fetch_team_data(soup)
+def test_get_depth_chart_skips_rows_without_name_and_position():
+    html = """
+    <html>
+        <body>
+            <table>
+                <tr>
+                    <td>QB</td>
+                    <td>Anthony Richardson</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <td>RB</td>
+                    <td>Jonathan Taylor</td>
+                </tr>
+                <tr>
+                    <td>QB</td>
+                </tr>
+            </table>
+        </body>
+    </html>
+    """
+    soup = BeautifulSoup(html, 'html.parser')
+    team = "Indianapolis Colts"
     
-    # assert 
-    assert actual_output == expected_output, f"Expected {expected_output}, got {actual_output}"
+    # expected data doesn't include empty cells
+    expected_data = [
+        {"player_name": "Anthony Richardson", "position": "QB", "team": team},
+        {"player_name": "Jonathan Taylor", "position": "RB", "team": team}
+    ]
     
+    result = fantasy_pros_scraper.get_depth_chart(soup, team)
+    assert result == expected_data


### PR DESCRIPTION
We needed to refactor the fantasy football scraper to no longer fetch **all** depth charts from the single PHP page. Fantasy pros scraper introduced some functionality to inhibit use from scraping more than three teams, so we will instead fetch player information from _each teams depth chart page_. 