### PR TITLE
Add Calculating Fantasy Points Functionality 

### DIFF
--- a/scrape_and_score/db/fetch_data.py
+++ b/scrape_and_score/db/fetch_data.py
@@ -316,7 +316,7 @@ def fetch_all_player_game_logs_for_recent_week(year: int):
       connection = get_connection()
 
       with connection.cursor() as cur:
-            cur.execute(sql, (year))  
+            cur.execute(sql, (year,))  
             rows = cur.fetchall()
             
             if rows:
@@ -372,7 +372,7 @@ def fetch_all_player_game_logs_for_given_year(year: int):
       connection = get_connection()
 
       with connection.cursor() as cur:
-            cur.execute(sql, (year))  
+            cur.execute(sql, (year,))  
             rows = cur.fetchall()
             
             if rows:

--- a/scrape_and_score/db/fetch_data.py
+++ b/scrape_and_score/db/fetch_data.py
@@ -263,7 +263,7 @@ def fetch_player_game_log_by_pk(pk: dict):
 
       with connection.cursor() as cur:
             cur.execute(sql, (pk['player_id'], pk['week'], pk['year']))  
-            row = cur.fetchone()  
+            row = cur.fetchone() 
             
             if row:
                player_game_log = {
@@ -298,4 +298,115 @@ def fetch_player_game_log_by_pk(pk: dict):
       raise e
    
    return player_game_log
+
+'''
+Functionality to retrieve all player game logs for the most recent week 
+
+Args:
+   year (int): year to fetch game logs for 
+
+Returns:
+   game_logs (list): list of game logs for given year & recent week
+'''
+def fetch_all_player_game_logs_for_recent_week(year: int):
+   sql = 'SELECT * FROM player_game_log WHERE year=%s AND week=(SELECT MAX(week) FROM player_game_log)'
+   player_game_logs = []
    
+   try:
+      connection = get_connection()
+
+      with connection.cursor() as cur:
+            cur.execute(sql, (year))  
+            rows = cur.fetchall()
+            
+            if rows:
+               for row in rows:
+                  player_game_log = {
+                     'player_id': row[0],
+                     'week': row[1],
+                     'day': row[2],
+                     'year': row[3],
+                     'home_team': row[4],
+                     'opp': row[5],
+                     'result': row[6], 
+                     'points_for': row[7],
+                     'points_allowed': row[8],
+                     'completions': row[9],
+                     'attempts': row[10],
+                     'pass_yd': row[11], 
+                     'pass_td': row[12],
+                     'interceptions': row[13], 
+                     'rating': row[14], 
+                     'sacked': row[15], 
+                     'rush_att': row[16], 
+                     'rush_yds': row[17], 
+                     'rush_tds': row[18], 
+                     'tgt': row[19], 
+                     'rec': row[20], 
+                     'rec_yd': row[21], 
+                     'rec_td': row[22], 
+                     'snap_pct': row[23]
+                  }
+                  player_game_logs.append(player_game_log)
+
+   except Exception as e:
+      logging.error(f"An error occurred while fetching all recent week player game logs: {e}")
+      raise e
+   
+   return player_game_logs
+
+'''
+Functionality to retrieve all player game logs for a given year 
+
+Args:
+   year (int): year to fetch game logs for 
+   
+Returns:
+   game_logs (list): list of player game logs for given year
+'''
+def fetch_all_player_game_logs_for_given_year(year: int):
+   sql = 'SELECT * FROM player_game_log WHERE year=%s'
+   player_game_logs = []
+   
+   try:
+      connection = get_connection()
+
+      with connection.cursor() as cur:
+            cur.execute(sql, (year))  
+            rows = cur.fetchall()
+            
+            if rows:
+               for row in rows:
+                  player_game_log = {
+                     'player_id': row[0],
+                     'week': row[1],
+                     'day': row[2],
+                     'year': row[3],
+                     'home_team': row[4],
+                     'opp': row[5],
+                     'result': row[6], 
+                     'points_for': row[7],
+                     'points_allowed': row[8],
+                     'completions': row[9],
+                     'attempts': row[10],
+                     'pass_yd': row[11], 
+                     'pass_td': row[12],
+                     'interceptions': row[13], 
+                     'rating': row[14], 
+                     'sacked': row[15], 
+                     'rush_att': row[16], 
+                     'rush_yds': row[17], 
+                     'rush_tds': row[18], 
+                     'tgt': row[19], 
+                     'rec': row[20], 
+                     'rec_yd': row[21], 
+                     'rec_td': row[22], 
+                     'snap_pct': row[23]
+                  }
+                  player_game_logs.append(player_game_log)
+
+   except Exception as e:
+      logging.error(f"An error occurred while fetching all recent week player game logs: {e}")
+      raise e
+   
+   return player_game_logs

--- a/scrape_and_score/db/insert_data.py
+++ b/scrape_and_score/db/insert_data.py
@@ -221,4 +221,28 @@ def insert_wr_or_te_player_game_logs(game_logs: list):
 
    
 
+'''
+Functionality to update player game log with calculated fantasy points
 
+Args:
+   fantasy_points (list): list of items containing player_game_log PK and their fantasy points
+
+Returns: 
+   None
+'''
+def add_fantasy_points(fantasy_points: list): 
+   sql = 'UPDATE player_game_log SET fantasy_points = %s WHERE player_id = %s AND week = %s AND year = %s'
+   
+   try:
+      connection = get_connection()
+      
+      params = [(log["fantasy_points"], log["player_id"], log["week"], log["year"]) for log in fantasy_points] # create needed tuples for executemany functionality
+
+      with connection.cursor() as cur:
+         cur.executemany(sql, params)
+         connection.commit()
+         logging.info(f"Successfully inserted {len(fantasy_points)} players fantasy points into the database")
+
+   except Exception as e:
+      logging.error(f"An exception occurred while inserting the follwoing fantasy points: {fantasy_points}", exc_info=True)
+      raise e

--- a/scrape_and_score/resources/application.yaml
+++ b/scrape_and_score/resources/application.yaml
@@ -13,6 +13,24 @@ website:
 scraping:
    delay: 3
 
+# scoring
+scoring:
+   offense:
+      passing:
+         yards: 0.04
+         td: 4
+         int: -2
+         two_pt_conversion: 2
+      rushing:
+         yards: 0.1
+         td: 6
+         two_pt_conversion: 2
+      receiving:
+         yards: 0.1
+         rec: 1
+         td: 6
+         two_pt_conversion: 2
+
 # NFL teams
 nfl:
    current-year: 2024

--- a/scrape_and_score/resources/application.yaml
+++ b/scrape_and_score/resources/application.yaml
@@ -17,16 +17,16 @@ scraping:
 scoring:
    offense:
       passing:
-         yards: 0.04
+         yard: 0.04
          td: 4
          int: -2
          two_pt_conversion: 2
       rushing:
-         yards: 0.1
+         yard: 0.1
          td: 6
          two_pt_conversion: 2
       receiving:
-         yards: 0.1
+         yard: 0.1
          rec: 1
          td: 6
          two_pt_conversion: 2

--- a/scrape_and_score/service/player_game_logs_service.py
+++ b/scrape_and_score/service/player_game_logs_service.py
@@ -248,6 +248,111 @@ def remove_previously_inserted_games(player_metrics, depth_charts):
          logging.debug(f'Player game log corresponding to PK [{player_metric_pks[index]}] not persisted; inserting new game log')
          index +=1
 
+'''
+Functionaltiy to calculate the fantasy points for players 
 
- 
+TODO (FFM-128): Account for 2-Pt Conversions
+
+Args:
+   recent_game (bool): flag to indicate if we should only be accounting for most recent game or all games 
+   year (int): year that game log occured 
+
+Returns:
+   None
+'''
+def calculate_fantasy_points(recent_game: bool, year: int):
+   if recent_game:
+      player_game_logs = fetch_data.fetch_all_player_game_logs_for_recent_week(year)
+   else:
+      player_game_logs = fetch_data.fetch_all_player_game_logs_for_given_year(year)
+   logging.info(f'Successfully fetched {len(player_game_logs)} player game logs')
    
+   passing_yd_pts, passing_td_pts, passing_int_pts, rushing_yd_pts, rushing_td_pts, receiving_yd_pts, receiving_td_pts, receiving_pts = get_offensive_point_configs()
+   
+   players_points = [] 
+   for player_game_log in player_game_logs:
+      points = calculate_point_total(player_game_log, passing_yd_pts, passing_td_pts, passing_int_pts, rushing_yd_pts, rushing_td_pts, receiving_yd_pts, receiving_td_pts, receiving_pts)
+      players_points.append({"player_id": player_game_log['player_id'], "week": player_game_log['week'], "year": player_game_log['year'], "fantasy_points": points})
+   
+   insert_fantasy_points(players_points)
+   
+
+'''
+Functionality to calculate the total points a player
+
+
+TODO (FFM-128): Account for 2-Pt Conversions
+
+Args:
+   player_game_log (dict): item containing all relevant stats needed to make calculations 
+   passing_yd_pts (float): # of fantasy points for a passing yard
+   passing_td_pts (int): # of fantasy points for a passing td 
+   passing_int_pts (int): # of fantasy points for a passing interception
+   rushing_yd_pts (float): # of fantasy points for a rushing yard
+   rushing_td_pts (int): # of fantasy points for a rushing td 
+   receiving_yd_pts (float): # of fantasy points for a receiving yard
+   receiving_td_pts (int): # of fantasy points for a receiving td 
+   receiving_pts (int): # of fantasy points for a reception
+   
+Returns:
+   points (float): total fantasy points for a player based on their game log
+'''
+def calculate_point_total(player_game_log, passing_yd_pts, passing_td_pts, passing_int_pts, rushing_yd_pts, rushing_td_pts, receiving_yd_pts, receiving_td_pts, receiving_pts):
+   return round(
+      ((player_game_log.get('interceptions', 0) or 0) * passing_int_pts) + \
+      ((player_game_log.get('pass_yd', 0) or 0) * passing_yd_pts) + \
+      ((player_game_log.get('pass_td', 0) or 0) * passing_td_pts) + \
+      ((player_game_log.get('rush_yds', 0) or 0) * rushing_yd_pts) + \
+      ((player_game_log.get('rush_tds', 0) or 0) * rushing_td_pts) + \
+      ((player_game_log.get('rec_yd', 0) or 0) * receiving_yd_pts) + \
+      ((player_game_log.get('rec_td', 0) or 0) * receiving_td_pts) + \
+      ((player_game_log.get('rec', 0) or 0) * receiving_pts), 2
+   )
+
+'''
+Functionality to insert a fantasy points into our DB 
+
+Args:
+   points (list): list of dictionaries containing player_game_log PK & corresponding fantasy points for that week
+
+Returns:
+   None
+'''
+def insert_fantasy_points(points: list):
+   if points == []:
+      logging.info('No fantasy points were calculated; skipping insertion')
+      return 
+   
+   logging.info(f'Attempting to insert plaers fantasy points into our DB')
+   insert_data.add_fantasy_points(points)
+
+
+'''
+Utility function to retrieve fantasy points scoring configs 
+
+Args:
+   None
+
+Returns:
+   passing_yd_pts, passing_td_pts, passing_int_pts, rushing_yd_pts, rushing_td_pts, receiving_yd_pts, receiving_td_pts, receiving_pts (tuple): 
+      scoring system for offensive player
+'''
+def get_offensive_point_configs():
+   passing_yd_pts = props.get_config('scoring.offense.passing.yard')
+   passing_td_pts = props.get_config('scoring.offense.passing.td')
+   passing_int_pts = props.get_config('scoring.offense.passing.int')
+   
+   rushing_yd_pts = props.get_config('scoring.offense.rushing.yard')
+   rushing_td_pts = props.get_config('scoring.offense.rushing.td')
+   
+   receiving_yd_pts = props.get_config('scoring.offense.receiving.yard')
+   receiving_td_pts = props.get_config('scoring.offense.receiving.td')
+   receiving_pts = props.get_config('scoring.offense.receiving.rec')
+   
+   logging.info(f'Configured offensive fantasy points scoring: '
+            f'[Passing Yd: {passing_yd_pts}, Passing TD: {passing_td_pts}, '
+            f'Passing INT: {passing_int_pts}, Rushing Yd: {rushing_yd_pts}, '
+            f'Rushing TD: {rushing_td_pts}, Receiving Yd: {receiving_yd_pts}, '
+            f'Receiving TD: {receiving_td_pts}, Receiving Rec: {receiving_pts}]')
+   
+   return passing_yd_pts, passing_td_pts, passing_int_pts, rushing_yd_pts, rushing_td_pts, receiving_yd_pts, receiving_td_pts, receiving_pts

--- a/scrape_and_score/service/player_game_logs_service.py
+++ b/scrape_and_score/service/player_game_logs_service.py
@@ -281,7 +281,7 @@ def calculate_fantasy_points(recent_game: bool, year: int):
 Functionality to calculate the total points a player
 
 
-TODO (FFM-128): Account for 2-Pt Conversions
+TODO (FFM-128): Account for 2-Pt Conversions and Fumbles 
 
 Args:
    player_game_log (dict): item containing all relevant stats needed to make calculations 

--- a/scrape_and_score/sql/create_player_game_log_table.sql
+++ b/scrape_and_score/sql/create_player_game_log_table.sql
@@ -23,6 +23,7 @@ CREATE TABLE player_game_log (
     rec_yd INT,
     rec_td INT,
     snap_pct INT,
+    fantasy_points FLOAT,
     PRIMARY KEY (player_id, week, year),
     FOREIGN KEY (player_id) REFERENCES player(player_id) ON DELETE CASCADE,
     FOREIGN KEY (opp) REFERENCES team(team_id) ON DELETE CASCADE

--- a/scrape_and_score/sql/create_team_game_log_table.sql
+++ b/scrape_and_score/sql/create_team_game_log_table.sql
@@ -16,6 +16,7 @@ CREATE TABLE team_game_log (
     opp_tot_yds INT,
     opp_pass_yds INT,
     opp_rush_yds INT,
+    fantasy_points FLOAT,
     PRIMARY KEY (team_id, week, year),
     FOREIGN KEY (team_id) REFERENCES team(team_id) ON DELETE CASCADE,
     FOREIGN KEY (opp) REFERENCES team(team_id) ON DELETE CASCADE

--- a/scrape_and_score/tests/db/fetch_data_test.py
+++ b/scrape_and_score/tests/db/fetch_data_test.py
@@ -518,7 +518,7 @@ def test_fetch_all_player_game_logs_for_recent_week_executes_expected_sql(mock_g
     
     mock_cursor.execute.assert_called_once_with(
         'SELECT * FROM player_game_log WHERE year=%s AND week=(SELECT MAX(week) FROM player_game_log)',
-        (2024)
+        (2024,)
     )
 
 @patch('db.fetch_data.get_connection')
@@ -596,7 +596,7 @@ def test_fetch_all_player_game_logs_for_given_year_executes_expected_sql(mock_ge
     
     mock_cursor.execute.assert_called_once_with(
         'SELECT * FROM player_game_log WHERE year=%s',
-        (2024)
+        (2024,)
     )
 
 @patch('db.fetch_data.get_connection')

--- a/scrape_and_score/tests/db/fetch_data_test.py
+++ b/scrape_and_score/tests/db/fetch_data_test.py
@@ -211,7 +211,7 @@ def test_fetch_team_by_name_returns_no_team(mock_get_connection):
 @patch('db.fetch_data.get_connection', side_effect=Exception('Database connection failed'))
 def test_fetch_team_by_name_throws_exception(mock_get_connection):
     try:
-        actual_team = fetch_data.fetch_team_by_name('Team A') 
+        fetch_data.fetch_team_by_name('Team A') 
     except Exception as e:
         assert str(e) == 'Database connection failed'
 
@@ -457,4 +457,159 @@ def test_fetch_one_player_game_log_when_no_records_persisted(mock_get_connection
     actual_player_game_log = fetch_data.fetch_one_player_game_log()
     
     assert actual_player_game_log == expected_player_game_log
+
+
+@patch('db.fetch_data.get_connection')
+def test_fetch_all_player_game_logs_for_recent_week_returns_expected_list(mock_get_connection):
+    expected_player_game_log = {
+        'player_id': 527,
+        'week': 2,
+        'day': 16,
+        'year': 2024,
+        'home_team': True,
+        'opp': 45,
+        'result': 'W',
+        'points_for': 30,
+        'points_allowed': 20,
+        'completions': 25,
+        'attempts': 35,
+        'pass_yd': 300,
+        'pass_td': 3,
+        'interceptions': 1,
+        'rating': 105.5,
+        'sacked': 2,
+        'rush_att': 10,
+        'rush_yds': 50,
+        'rush_tds': 1,
+        'tgt': 5,
+        'rec': 4,
+        'rec_yd': 60,
+        'rec_td': 1,
+        'snap_pct': 85.0
+    }
+    expected_game_logs = [expected_player_game_log]
     
+    mock_connection = MagicMock() 
+    
+    mock_cursor = MagicMock() 
+    mock_cursor.execute.return_value = None
+    mock_cursor.fetchall.return_value = [(527, 2, 16, 2024, True, 45, 'W', 30, 20, 25, 35, 300, 3, 1, 105.5, 2, 10, 50, 1, 5, 4, 60, 1, 85.0)]
+    
+    mock_connection.cursor.return_value.__enter__.return_value = mock_cursor 
+    mock_get_connection.return_value = mock_connection
+    
+    actual_game_logs = fetch_data.fetch_all_player_game_logs_for_recent_week(2024)
+    
+    assert actual_game_logs == expected_game_logs
+
+@patch('db.fetch_data.get_connection')
+def test_fetch_all_player_game_logs_for_recent_week_executes_expected_sql(mock_get_connection): 
+    
+    mock_connection = MagicMock() 
+    
+    mock_cursor = MagicMock() 
+    mock_cursor.execute.return_value = None
+    mock_cursor.fetchall.return_value = None
+    
+    mock_connection.cursor.return_value.__enter__.return_value = mock_cursor 
+    mock_get_connection.return_value = mock_connection
+    
+    fetch_data.fetch_all_player_game_logs_for_recent_week(2024)
+    
+    mock_cursor.execute.assert_called_once_with(
+        'SELECT * FROM player_game_log WHERE year=%s AND week=(SELECT MAX(week) FROM player_game_log)',
+        (2024)
+    )
+
+@patch('db.fetch_data.get_connection')
+def test_fetch_all_player_game_logs_for_recent_week_calls_expected_functions(mock_get_connection): 
+    mock_connection = MagicMock() 
+    
+    mock_cursor = MagicMock() 
+    mock_cursor.execute.return_value = None
+    mock_cursor.fetchall.return_value = None
+    
+    mock_connection.cursor.return_value.__enter__.return_value = mock_cursor 
+    mock_get_connection.return_value = mock_connection
+    
+    fetch_data.fetch_all_player_game_logs_for_recent_week(2024)
+    
+    mock_get_connection.assert_called_once()
+
+
+@patch('db.fetch_data.get_connection')
+def test_fetch_all_player_game_logs_for_given_year_returns_expected_list(mock_get_connection):
+    expected_player_game_log = {
+        'player_id': 527,
+        'week': 2,
+        'day': 16,
+        'year': 2024,
+        'home_team': True,
+        'opp': 45,
+        'result': 'W',
+        'points_for': 30,
+        'points_allowed': 20,
+        'completions': 25,
+        'attempts': 35,
+        'pass_yd': 300,
+        'pass_td': 3,
+        'interceptions': 1,
+        'rating': 105.5,
+        'sacked': 2,
+        'rush_att': 10,
+        'rush_yds': 50,
+        'rush_tds': 1,
+        'tgt': 5,
+        'rec': 4,
+        'rec_yd': 60,
+        'rec_td': 1,
+        'snap_pct': 85.0
+    }
+    expected_game_logs = [expected_player_game_log]
+    
+    mock_connection = MagicMock() 
+    
+    mock_cursor = MagicMock() 
+    mock_cursor.execute.return_value = None
+    mock_cursor.fetchall.return_value = [(527, 2, 16, 2024, True, 45, 'W', 30, 20, 25, 35, 300, 3, 1, 105.5, 2, 10, 50, 1, 5, 4, 60, 1, 85.0)]
+    
+    mock_connection.cursor.return_value.__enter__.return_value = mock_cursor 
+    mock_get_connection.return_value = mock_connection
+    
+    actual_game_logs = fetch_data.fetch_all_player_game_logs_for_given_year(2024)
+    
+    assert actual_game_logs == expected_game_logs
+
+@patch('db.fetch_data.get_connection')
+def test_fetch_all_player_game_logs_for_given_year_executes_expected_sql(mock_get_connection): 
+    
+    mock_connection = MagicMock() 
+    
+    mock_cursor = MagicMock() 
+    mock_cursor.execute.return_value = None
+    mock_cursor.fetchall.return_value = None
+    
+    mock_connection.cursor.return_value.__enter__.return_value = mock_cursor 
+    mock_get_connection.return_value = mock_connection
+    
+    fetch_data.fetch_all_player_game_logs_for_given_year(2024)
+    
+    mock_cursor.execute.assert_called_once_with(
+        'SELECT * FROM player_game_log WHERE year=%s',
+        (2024)
+    )
+
+@patch('db.fetch_data.get_connection')
+def test_fetch_all_player_game_logs_for_given_year_calls_expected_functions(mock_get_connection): 
+    mock_connection = MagicMock() 
+    
+    mock_cursor = MagicMock() 
+    mock_cursor.execute.return_value = None
+    mock_cursor.fetchall.return_value = None
+    
+    mock_connection.cursor.return_value.__enter__.return_value = mock_cursor 
+    mock_get_connection.return_value = mock_connection
+    
+    fetch_data.fetch_all_player_game_logs_for_given_year(2024)
+    
+    mock_get_connection.assert_called_once()

--- a/scrape_and_score/tests/service/player_game_logs_service_test.py
+++ b/scrape_and_score/tests/service/player_game_logs_service_test.py
@@ -478,3 +478,73 @@ def test_get_wr_or_te_game_log_tuples_calls_expected_functions(mock_get_team_nam
    mock_get_home_team.assert_called_once()
    mock_get_team_name.assert_called_once()
    mock_get_team_id.assert_called_once()
+
+
+def test_calculate_point_total_returns_expected_points():
+   passing_yd_pts = .04
+   pass_td_pts = 4
+   interception_pts = -2
+   rush_yd_pts = .1
+   rush_td_pts = 6
+   rec_yd_pts = .1
+   rec_td_pts = 6
+   rec_pts = 1
+   game_log = {
+      'pass_yd': 250,
+      'pass_td': 2,
+      'interceptions': 1,
+      'rush_yds': 30,
+      'rush_tds': 1,
+      'rec_yd': 45,
+      'rec_td': 1,
+      'rec': 6
+   }
+   
+   expected_total = (250 * .04) + (2 * 4) + (1 * -2) + (30 * .1) + (1 * 6) + (45 * .1) + (1 * 6) + (6 * 1)
+   
+   assert player_game_logs_service.calculate_point_total(
+      game_log,
+      passing_yd_pts, 
+      pass_td_pts, 
+      interception_pts,
+      rush_yd_pts, 
+      rush_td_pts,
+      rec_yd_pts,
+      rec_td_pts,
+      rec_pts) == expected_total
+   
+   
+def test_calculate_point_total_returns_expected_points():
+   passing_yd_pts = .04
+   pass_td_pts = 4
+   interception_pts = -2
+   rush_yd_pts = .1
+   rush_td_pts = 6
+   rec_yd_pts = .1
+   rec_td_pts = 6
+   rec_pts = 1
+   game_log = {
+      'pass_yd': None,
+      'pass_td': None,
+      'interceptions': None,
+      'rush_yds': None,
+      'rush_tds': None,
+      'rec_yd': None,
+      'rec_td': None,
+      'rec': None
+   }
+   
+   expected_total = 0
+   
+   assert player_game_logs_service.calculate_point_total(
+      game_log,
+      passing_yd_pts, 
+      pass_td_pts, 
+      interception_pts,
+      rush_yd_pts, 
+      rush_td_pts,
+      rec_yd_pts,
+      rec_td_pts,
+      rec_pts) == expected_total 
+
+

--- a/scrape_and_score/tests/service/player_game_logs_service_test.py
+++ b/scrape_and_score/tests/service/player_game_logs_service_test.py
@@ -76,7 +76,7 @@ def test_remove_previously_inserted_games_calls_expected_functions(mock_get_play
 
    mock_get_player_id.assert_called_once()
    mock_extract_year.assert_called_once()
-   mock_is_game_log_persisted.assert_called_once_with({'player_id': 14, 'week': 1, 'year': 2024})
+   mock_is_game_log_persisted.assert_called_once_with({'player_id': 14, 'week': '1', 'year': 2024})
 
 
 

--- a/scrape_and_score/tests/service/team_game_logs_service_test.py
+++ b/scrape_and_score/tests/service/team_game_logs_service_test.py
@@ -40,7 +40,7 @@ def test_remove_previously_inserted_games_skips_removal_when_not_recent_games(mo
       'opp_rush_yds': [100, 232],
    }
    team_metrics = [{"team_name": "My Team", "team_metrics": pd.DataFrame(data=data)}]
-   team_game_logs_service.remove_previously_inserted_game_logs(team_metrics, 2024)
+   team_game_logs_service.remove_previously_inserted_game_logs(team_metrics, 2024, [])
    assert mock_is_game_log_persisted.call_count == 0 # skips when not only recent games 
 
 @patch('service.team_game_logs_service.is_game_log_persisted', return_value = True) 
@@ -66,9 +66,9 @@ def test_remove_previously_inserted_games_calls_expected_functions(mock_get_id, 
    }
    team_metrics = [{"team_name": "My Team", "team_metrics": pd.DataFrame(data=data)}]
 
-   team_game_logs_service.remove_previously_inserted_game_logs(team_metrics, 2024)
+   team_game_logs_service.remove_previously_inserted_game_logs(team_metrics, 2024, [])
 
-   mock_is_game_log_persisted.assert_called_once_with({"team_id": 14, "week": 1, "year": 2024})
+   mock_is_game_log_persisted.assert_called_once_with({"team_id": 14, "week": '1', "year": 2024})
    mock_get_game_log_year.assert_called_once()
    mock_get_id.assert_called_once()
 
@@ -79,7 +79,7 @@ def test_remove_previously_inserted_games__deletes_entries_from_player_metrics(m
    data = { 'week': [2] }
    team_metrics = [{"team_name": "My Team", "team_metrics": pd.DataFrame(data=data)}]
 
-   team_game_logs_service.remove_previously_inserted_game_logs(team_metrics, 2024)
+   team_game_logs_service.remove_previously_inserted_game_logs(team_metrics, 2024, [])
 
    assert len(team_metrics) == 0
 
@@ -106,7 +106,7 @@ def test_remove_previously_inserted_games__deletes_entries_from_player_metrics(m
    }
    team_metrics = [{"team_name": "My Team", "team_metrics": pd.DataFrame(data=data)}]
 
-   team_game_logs_service.remove_previously_inserted_game_logs(team_metrics, 2024)
+   team_game_logs_service.remove_previously_inserted_game_logs(team_metrics, 2024, [])
 
    assert len(team_metrics) == 1
 


### PR DESCRIPTION
This is the needed code to calculate & update player game log records with their corresponding fantasy points for each week. This currently is for offensive players only.

**Note**: This functionality is missing the logic regarding a player _fumbling or running/receiving/passing for a 2pt conversion_, We have a follow up story down the line to account for the addition of this missing logic: https://budgetapp.atlassian.net/browse/FFM-128 