### PR TITLE
Add Offense/Defense Rushing/Passing Rankings for Teams 

### DIFF
--- a/scrape_and_score/__main__.py
+++ b/scrape_and_score/__main__.py
@@ -52,7 +52,6 @@ def main():
       depth_charts = fetch_all_players() 
       
       # fetch relevant team and player metrics 
-      #TODO: Fetch player game logs for given year and check if we have these persisted
       if player_game_logs_service.is_player_game_logs_empty(): # scrape & persist all game logs if none persisted
          team_metrics, player_metrics = pfr.scrape_all(depth_charts, teams)
          logging.info(f"Successfully retrieved metrics for {len(team_metrics)} teams and {len(player_metrics)} players")
@@ -76,7 +75,8 @@ def main():
          # calculate fantasy points for recent week 
          player_game_logs_service.calculate_fantasy_points(True, year)
          
-         
+
+      team_game_logs_service.calculate_all_teams_rankings(year)  
       
 
       logging.info(f'Application took {(datetime.now() - start_time).seconds} seconds to complete')

--- a/scrape_and_score/db/fetch_data.py
+++ b/scrape_and_score/db/fetch_data.py
@@ -410,3 +410,55 @@ def fetch_all_player_game_logs_for_given_year(year: int):
       raise e
    
    return player_game_logs
+
+
+'''
+Functionality to retrieve teams game logs for a particular season 
+
+Args:
+   year (int): year to fetch team game logs for 
+   team_id (int): team to fetch game logs for 
+
+Returns
+   game_logs (list): list of game_logs for a particular season/team
+'''
+def fetch_all_teams_game_logs_for_season(team_id: int, year:int): 
+   team_game_logs = []
+   sql = 'SELECT * FROM team_game_log WHERE team_id = %s AND year=%s'
+   
+   try:
+      connection = get_connection()
+
+      with connection.cursor() as cur:
+         cur.execute(sql, (team_id, year)) 
+         rows = cur.fetchall()
+         
+         for row in rows:
+            team_game_log = {
+               'team_id': row[0],
+               'week': row[1],
+               'day': row[2],
+               'year': row[3],
+               'rest_days': row[4],
+               'home_team': row[5],
+               'distance_traveled': row[6],
+               'opp': row[7],
+               'result': row[8],
+               'points_for': row[9],
+               'points_allowed': row[10],
+               'tot_yds': row[11],
+               'pass_yds': row[12],
+               'rush_yds': row[13],
+               'opp_tot_yds': row[14],
+               'opp_pass_yds': row[15],
+               'opp_rush_yds': row[16]
+            }
+
+            team_game_logs.append(team_game_log)
+
+   except Exception as e:
+      logging.error(f"An error occurred while fetching the team game logs corresponding to team {team_id} and year {year}: {e}")
+      raise e
+   
+   return team_game_logs
+   

--- a/scrape_and_score/db/insert_data.py
+++ b/scrape_and_score/db/insert_data.py
@@ -246,3 +246,28 @@ def add_fantasy_points(fantasy_points: list):
    except Exception as e:
       logging.error(f"An exception occurred while inserting the follwoing fantasy points: {fantasy_points}", exc_info=True)
       raise e
+
+
+'''
+Update 'team' record with newly determined rankings 
+
+Args:
+   rankings (list): list of rankings to persist 
+   col (str): column in 'team' to update based on rankings
+'''
+def update_team_rankings(rankings: list, col: str):
+   sql = f'UPDATE team SET {col} = %s WHERE team_id = %s'
+   
+   try:
+      connection = get_connection()
+      
+      params = [(rank['rank'], rank['team_id']) for rank in rankings] # create tuple needed to update records
+
+      with connection.cursor() as cur:
+         cur.executemany(sql, params)
+         connection.commit()
+         logging.info(f"Successfully updated {len(rankings)} {col} rankings in the database")
+
+   except Exception as e:
+      logging.error(f"An exception occurred while inserting the following rankings: {rankings}", exc_info=True)
+      raise e

--- a/scrape_and_score/resources/application.yaml
+++ b/scrape_and_score/resources/application.yaml
@@ -31,6 +31,11 @@ scoring:
          td: 6
          two_pt_conversion: 2
 
+rankings:
+  weights:
+    td: 0.6
+    yards: 0.4
+
 # NFL teams
 nfl:
    current-year: 2024

--- a/scrape_and_score/service/team_game_logs_service.py
+++ b/scrape_and_score/service/team_game_logs_service.py
@@ -125,6 +125,7 @@ Returns:
    game_logs (list): list of game logs corresponding to team
 '''
 def get_teams_game_logs_for_season(team_id: int, year: int):
+   logging.info(f'Fetching all game logs for the following team ID: {team_id} and year: {year}')
    return fetch_data.fetch_all_teams_game_logs_for_season(team_id, year)
 
 '''
@@ -179,16 +180,22 @@ def calculate_all_teams_rankings(curr_year: int):
    teams = team_service.get_all_teams()
 
    # accumulate relevant metrics (off/def) for given season for each team
+   logging.info(f'Aggergating relevant offensive and defensive metrics for the following season: {curr_year}')
    teams_metrics = [
     get_aggregate_season_metrics(get_teams_game_logs_for_season(team.get("team_id"), curr_year))
     for team in teams
    ]
 
    # calculate rankings 
-   team_rankings = calculate_rankings(teams_metrics)
+   off_rush_ranks, off_pass_ranks, def_rush_ranks, def_pass_ranks = calculate_rankings(teams_metrics)
+
+   logging.info(f'Offense Rush Ranks: {off_rush_ranks}\n\n')
+   logging.info(f'Offense Pass Ranks: {off_pass_ranks}\n\n')
+   logging.info(f'Defense Rush Ranks: {def_rush_ranks}\n\n')
+   logging.info(f'Defense Pass Ranks: {def_pass_ranks}\n\n')
 
    # persist rankings
-   update_teams_rankings(team_rankings)
+   update_teams_rankings(off_rush_ranks, off_pass_ranks, def_rush_ranks, def_pass_ranks)
 
 
 
@@ -200,11 +207,54 @@ Args:
    team_game_logs (list): list of game logs for a particular team 
 
 Returns:
-   rankings (list): list of dictionary items containing team_id & relevant off/def rankings 
+   off_rush_ranks, off_pass_ranks, def_rush_ranks, def_pass_ranks (tuple): tuple containing teams respective rankings 
 '''
 def calculate_rankings(metrics: list):
-   #TODO: Finalize implementation using weighted averages of points for/against & relevant yardages
-   return None
+   logging.info('Attempting to calculate offensive/defensive rush/pass rankings for each team based on metrics')
+   off_rush_weighted_sums, def_rush_weighted_sums, off_pass_weighted_sums, def_pass_weighted_sums = [], [], [], []
+
+   # normalize metrics & apply corresponding weights
+   weighted_metrics = normalize_metrics_and_apply_weights(metrics)
+
+   logging.info('Creating lists with weighted sums for each relevant metric: off_rushing, off_passing, def_rushing, and def_passing')
+   for metric in weighted_metrics:
+      off_rush_weighted_sums.append({'team_id': metric['team_id'], 'total': metric['points_for'] + metric['rush_yards_for']})
+      def_rush_weighted_sums.append({'team_id': metric['team_id'], 'total': metric['points_against'] + metric['rush_yards_against']})
+      off_pass_weighted_sums.append({'team_id': metric['team_id'], 'total': metric['points_for'] + metric['pass_yards_for']})
+      def_pass_weighted_sums.append({'team_id': metric['team_id'], 'total': metric['points_against'] + metric['pass_yards_against']})
+
+   # sort each list by their total (lower indicies are higher ranks)
+   logging.info('Sorting weighted sums in ascending order for defenenses, and descending order for offenses (lower index, higher rank)')
+   off_rush_weighted_sums = sorted(off_rush_weighted_sums, key=lambda x: x['total'], reverse=True) 
+   def_rush_weighted_sums = sorted(def_rush_weighted_sums, key=lambda x: x['total'], reverse=False) 
+   off_pass_weighted_sums = sorted(off_pass_weighted_sums, key=lambda x: x['total'], reverse=True)  
+   def_pass_weighted_sums = sorted(def_pass_weighted_sums, key=lambda x: x['total'], reverse=False) 
+
+   # get team rankings 
+   logging.info('Calculating team ranks based on corresponding order in each respective list [off_rush_ranks, off_pass_ranks, def_rush_ranks, def_pass_ranks]')
+   off_rush_ranks = [{'team_id': value['team_id'], 'rank': index + 1} for index,value in enumerate(off_rush_weighted_sums)]
+   off_pass_ranks = [{'team_id': value['team_id'], 'rank': index + 1} for index,value in enumerate(off_pass_weighted_sums)]
+   def_rush_ranks = [{'team_id': value['team_id'], 'rank': index + 1} for index,value in enumerate(def_rush_weighted_sums)]
+   def_pass_ranks = [{'team_id': value['team_id'], 'rank': index + 1} for index,value in enumerate(def_pass_weighted_sums)]
+
+   return off_rush_ranks, off_pass_ranks, def_rush_ranks, def_pass_ranks
+
+
+
+'''
+Determine rankings based on off/def for each team 
+
+Args:
+   weighted_sums (list): list of dictionary items sorted by their weighted sums (lower indicies, higher rank)
+
+Returns: 
+   
+''' 
+def get_rankings(weighted_sums: list):
+   ranks = [{'team_id': value['team_id'], 'rank': index} for index,value in enumerate(weighted_sums)]
+   return ranks
+
+
 
 
 
@@ -225,10 +275,15 @@ def get_aggregate_season_metrics(team_game_logs: list):
       raise Exception("Unable to obtain relevant off/def metrics because no team game logs were passed")
 
    # metrics to account for
-   points_for, points_against, pass_yards_for, pass_yards_against, rush_yards_for, rush_yards_against = (0, 0, 0, 0, 0, 0)
+   points_for = 0
+   points_against = 0
+   pass_yards_for = 0
+   pass_yards_against = 0
+   rush_yards_for = 0
+   rush_yards_against = 0
 
    for game_log in team_game_logs:
-      points_for += game_log.get("points_for", 0), 0
+      points_for += game_log.get("points_for", 0)
       points_against += game_log.get("points_allowed", 0)
       pass_yards_for += game_log.get("pass_yds", 0)
       pass_yards_against += game_log.get("opp_pass_yds", 0)
@@ -250,10 +305,99 @@ def get_aggregate_season_metrics(team_game_logs: list):
 Persists updated team rankings 
 
 Args:
-   rankings (list): list of dictionary items containing rankins & corresponding team 
+   off_rush_ranks (list): offensive rush rankings
+   off_pass_ranks (list): offensive pass rankings
+   def_rush_ranks (list): defensive rush rankings
+   def_pass_ranks (list): defensive pass rankings
 
 Returns:
    None
 '''
-def update_teams_rankings(rankings: list):
-   return None
+def update_teams_rankings(off_rush_ranks, off_pass_ranks, def_rush_ranks, def_pass_ranks):
+   logging.info('Attempting to update team records with updated off/def passing/rushing rankings')
+   insert_data.update_team_rankings(off_rush_ranks, 'off_rush_rank')
+   insert_data.update_team_rankings(off_pass_ranks, 'off_pass_rank')
+   insert_data.update_team_rankings(def_pass_ranks, 'def_pass_rank')
+   insert_data.update_team_rankings(def_rush_ranks, 'def_rush_rank')
+
+
+'''
+Functionality to normalize players season metrics, ensuring metrics 
+like passing_yds & total points are on the same scale
+
+Args:
+   team_metrics (dict):  relevant in season metrics for a team
+
+Returns:
+   normalized (dict): metric with normalized values 
+'''
+def normalize_metrics_and_apply_weights(team_metrics: list): 
+   logging.info(f'Attempting to normalize relevant in season metrics and apply corresponding weights based on configurations')
+   keys = ["points_for", "points_against", "rush_yards_for", "rush_yards_against", "pass_yards_for", "pass_yards_against"]
+
+   # inialize min/max values with first values
+   min_metrics = {key: team_metrics[0].get(key) for key in keys} 
+   max_metrics = {key: team_metrics[0].get(key) for key in keys} 
+
+   # obtain min/max values for each respective key
+   for team in team_metrics[1:]: 
+      for key in keys:
+         value = team[key]
+         min_metrics[key] = min(value, min_metrics[key])
+         max_metrics[key] = max(value, max_metrics[key])
+
+   # normalize metrics & apply weights
+   weighted_metrics = []
+   for team in team_metrics:
+      for key in keys: 
+         curr_val = team[key]
+         max_value = max_metrics[key]
+         min_value = min_metrics[key]
+
+         if max_value - min_value > 0:
+            normalized_value = ((curr_val - min_value)/(max_value - min_value))
+         else:
+            normalized_value = 0
+         team[key] = normalized_value
+      
+      # apply weights 
+      weighted_metrics.append(apply_weights(team, keys, team['team_id']))
+   
+   return weighted_metrics
+
+
+   
+
+
+
+'''
+Apply weights determined in configurations to normalized aggregate season metrics in order to properly rank 
+
+TODO (FFM-129): Optimize Points_For & Points_Against to account for where points came from when applying weights (i.e passing tds/rushing tds/def tds)
+
+Args:
+   normalized_metrics (dict): normalized metrics to apply weights to 
+   keys (list): list of keys corresponding to metrics
+   team_id (int): id corresponding to team metrics apply to
+
+Returns: 
+   weighted_metrics (list): metrics with weights applied 
+'''
+def apply_weights(normalized_metrics: dict, keys: list, team_id: int):
+   yd_weight = props.get_config('rankings.weights.yards')
+   td_weight = props.get_config('rankings.weights.td')
+
+   weights = {
+      "points_for": td_weight,
+      "points_against": td_weight,
+      "rush_yards_for": yd_weight,
+      "rush_yards_against": yd_weight,
+      "pass_yards_for": yd_weight,
+      "pass_yards_against": yd_weight
+   }
+
+   weighted_metrics = {key: normalized_metrics[key] * weights[key] for key in keys}
+   weighted_metrics['team_id'] = team_id # add team id to dict 
+
+   logging.info(f'Weighted metrics: [{weighted_metrics}]\n\n')
+   return weighted_metrics

--- a/scrape_and_score/service/team_game_logs_service.py
+++ b/scrape_and_score/service/team_game_logs_service.py
@@ -115,6 +115,19 @@ def is_game_log_persisted(game_log_pk: dict):
 
 
 '''
+Functionality to retrieve all game logs for a particular season 
+
+Args:
+   team_id (int): team ID to fetch game logs for
+   year (int): year to fetch game logs for 
+
+Returns:
+   game_logs (list): list of game logs corresponding to team
+'''
+def get_teams_game_logs_for_season(team_id: int, year: int):
+   return fetch_data.fetch_all_teams_game_logs_for_season(team_id, year)
+
+'''
 Utility function to determine if a teams game log has previously been inserted 
 
 Args: 
@@ -149,3 +162,63 @@ def remove_previously_inserted_game_logs(team_metrics, curr_year, teams_and_ids)
       else:
          logging.debug(f'Team game log corresponding to PK [{team_metric_pks[index]}] not persisted; inserting new game log')
          index +=1
+
+'''
+Functionality to calculate rankings (offense & defense) for a team
+
+Args:
+   curr_year (int): year to take into account when fetching rankings 
+
+Returns 
+   None 
+'''
+def calculate_team_rankings(curr_year: int):
+   # fetch all teams 
+   teams = team_service.get_all_teams()
+   
+   for team in teams: 
+      # fetch team game logs 
+      team_game_logs = get_teams_game_logs_for_season(team.get("team_id"), curr_year)
+      
+      
+      
+   
+   '''
+   a) For each team:
+      1) fetch game logs for relevant season 
+      2) accumulate metrics for offense 
+            - calculate_rush_rank 
+            - calculate_pass_rank 
+      3) accumulate metrics for defense 
+            - calculate_rush_rank
+            - calculate_pass_rank
+
+
+   '''
+
+'''
+Functionality to calculate the rankings of an offense based on their game logs for a given season 
+
+Args:
+   team_game_logs (list): list of game logs for a particular team 
+
+Returns:
+   off_rush_rank, off_pass_rank (tuple): rankings of the teams offense 
+'''
+def calculate_off_rankings(team_game_logs: list):
+   for game_log in team_game_logs:
+      # accumulate total passing yards 
+      
+      # accumulate total rushing yards 
+
+'''
+Functionality to calculate the rankings of a defense based on their game logs for a given season 
+
+Args:
+   team_game_logs (list): list of game logs for a particular team 
+
+Returns:
+   def_rush_rank, def_pass_rank (tuple): rankings of the teams offense 
+'''
+def calculate_def_rankings(team_game_logs: list):
+   return None

--- a/scrape_and_score/service/team_game_logs_service.py
+++ b/scrape_and_score/service/team_game_logs_service.py
@@ -172,53 +172,88 @@ Args:
 Returns 
    None 
 '''
-def calculate_team_rankings(curr_year: int):
+def calculate_all_teams_rankings(curr_year: int):
+   logging.info(f'Attemtping to calculate teams off/def rankings based on metrics for {curr_year} season')
+
    # fetch all teams 
    teams = team_service.get_all_teams()
-   
-   for team in teams: 
-      # fetch team game logs 
-      team_game_logs = get_teams_game_logs_for_season(team.get("team_id"), curr_year)
-      
-      
-      
-   
-   '''
-   a) For each team:
-      1) fetch game logs for relevant season 
-      2) accumulate metrics for offense 
-            - calculate_rush_rank 
-            - calculate_pass_rank 
-      3) accumulate metrics for defense 
-            - calculate_rush_rank
-            - calculate_pass_rank
+
+   # accumulate relevant metrics (off/def) for given season for each team
+   teams_metrics = [
+    get_aggregate_season_metrics(get_teams_game_logs_for_season(team.get("team_id"), curr_year))
+    for team in teams
+   ]
+
+   # calculate rankings 
+   team_rankings = calculate_rankings(teams_metrics)
+
+   # persist rankings
+   update_teams_rankings(team_rankings)
 
 
-   '''
+
 
 '''
-Functionality to calculate the rankings of an offense based on their game logs for a given season 
+Functionality to calculate the rankings of teams based on relevant metric accumulations
 
 Args:
    team_game_logs (list): list of game logs for a particular team 
 
 Returns:
-   off_rush_rank, off_pass_rank (tuple): rankings of the teams offense 
+   rankings (list): list of dictionary items containing team_id & relevant off/def rankings 
 '''
-def calculate_off_rankings(team_game_logs: list):
+def calculate_rankings(metrics: list):
+   #TODO: Finalize implementation using weighted averages of points for/against & relevant yardages
+   return None
+
+
+
+'''
+Obtain relevant offensive & defensive aggergated metrics (total tds, total pass yds, total rush_yds) for a team 
+
+Args:
+   team_game_logs (list): list of team game logs to obtain metrics for 
+
+Returns:
+   metrics (dict): dictionary containing following information
+      team_id, points_for, points_against, pass_yards_for, pass_yards_against, rush_yards_for, rush_yards_against 
+'''
+def get_aggregate_season_metrics(team_game_logs: list):
+   # ensure game logs passed
+   if not team_game_logs:
+      logging.error("Unable to get relevant season metrics for an empty list")
+      raise Exception("Unable to obtain relevant off/def metrics because no team game logs were passed")
+
+   # metrics to account for
+   points_for, points_against, pass_yards_for, pass_yards_against, rush_yards_for, rush_yards_against = (0, 0, 0, 0, 0, 0)
+
    for game_log in team_game_logs:
-      # accumulate total passing yards 
-      
-      # accumulate total rushing yards 
+      points_for += game_log.get("points_for", 0), 0
+      points_against += game_log.get("points_allowed", 0)
+      pass_yards_for += game_log.get("pass_yds", 0)
+      pass_yards_against += game_log.get("opp_pass_yds", 0)
+      rush_yards_for += game_log.get("rush_yds", 0)
+      rush_yards_against += game_log.get("opp_rush_yds", 0)
+   
+   return {
+      "team_id": team_game_logs[0].get("team_id"), 
+      "points_for": points_for,
+      "points_against": points_against,
+      "pass_yards_for": pass_yards_for, 
+      "pass_yards_against": pass_yards_against,
+      "rush_yards_for": rush_yards_for, 
+      "rush_yards_against": rush_yards_against
+   }
+
 
 '''
-Functionality to calculate the rankings of a defense based on their game logs for a given season 
+Persists updated team rankings 
 
 Args:
-   team_game_logs (list): list of game logs for a particular team 
+   rankings (list): list of dictionary items containing rankins & corresponding team 
 
 Returns:
-   def_rush_rank, def_pass_rank (tuple): rankings of the teams offense 
+   None
 '''
-def calculate_def_rankings(team_game_logs: list):
+def update_teams_rankings(rankings: list):
    return None

--- a/scrape_and_score/sql/create_team_table.sql
+++ b/scrape_and_score/sql/create_team_table.sql
@@ -1,6 +1,8 @@
 CREATE TABLE team (
     team_id SERIAL PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
-    offense_rank INT,
-    defense_rank INT
+    off_rush_rank INT,
+    off_pass_rank INT,
+    def_rush_rank INT,
+    def_pass_rank INT
 );

--- a/scrape_and_score/tests/service/team_game_logs_service_test.py
+++ b/scrape_and_score/tests/service/team_game_logs_service_test.py
@@ -236,3 +236,37 @@ def test_get_team_id_by_name_returns_expected_id_when_name_exists():
 def test_get_team_id_by_name_returns_none_when_name_doesnt_exist():
    teams_and_ids = [{"name": "Colts", "team_id": 12}, {"name": "Random", "team_id": 14}]
    assert team_game_logs_service.get_team_id_by_name('Fake', teams_and_ids) == None
+
+
+# def test_normalize_and_apply_weights_correctly_normalized_values(): 
+
+# def test_normalize_and_apply_weights_calls_expected_functions(): 
+
+# def test_apply_weights_returns_expected_dict(): 
+
+# def test_get_aggregate_season_metrics_returns_expected_aggregates(): 
+
+# def test_calculate_rankings_returns_expected_rankings(): 
+
+
+@patch('service.team_game_logs_service.update_teams_rankings')
+@patch('service.team_game_logs_service.calculate_rankings')
+@patch('service.team_game_logs_service.get_teams_game_logs_for_season')
+@patch('service.team_game_logs_service.get_aggregate_season_metrics')
+@patch('service.team_game_logs_service.team_service.get_all_teams')
+def test_calculate_all_team_rankings_calls_expected_functions(mock_get_all_teams, mock_get_aggregate_season_metrics, mock_get_team_game_logs, mock_calculate_rankings, mock_update_team_rankings): 
+   mock_list_of_dict = [{'team_id': '1'}]
+   
+   mock_get_all_teams.return_value = mock_list_of_dict
+   mock_get_aggregate_season_metrics.return_value =  mock_list_of_dict
+   mock_get_team_game_logs.return_value = mock_list_of_dict
+   mock_calculate_rankings.return_value = [{'team_id': 1}], [{'team_id': 1}], [{'team_id': 1}], [{'team_id': 1}]
+   
+   team_game_logs_service.calculate_all_teams_rankings(2024)
+   
+   mock_get_all_teams.assert_called_once()
+   mock_get_team_game_logs.assert_called_once()
+   mock_calculate_rankings.assert_called_once()
+   mock_get_aggregate_season_metrics.assert_called_once()
+   mock_update_team_rankings.assert_called_once() 
+   


### PR DESCRIPTION
The following PR adds needed functionality to calculate the following rankings: **1. offensive rushing ranking, 2. offensive passing ranking, 3. defensive passing ranking, 4. defensive rushing ranking**. These rankings are calculated via relevant game logs & their corresponding metrics (yards, tds, etc) for each team throughout the NFL season. 
